### PR TITLE
fixes minor typo in go.mod module

### DIFF
--- a/source/extensions/dynamic_modules/sdk/go/go.mod
+++ b/source/extensions/dynamic_modules/sdk/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/mathetake/envoy-dynamic-modules/source/extensions/dynmic_modules/sdk/go
+module github.com/mathetake/envoy-dynamic-modules/source/extensions/dynamic_modules/sdk/go
 
 go 1.22.5


### PR DESCRIPTION
A small typo was introduced in the folder restructuring.